### PR TITLE
fix: antlr build not adding header to generated lexer/parser

### DIFF
--- a/sympy/parsing/latex/_build_latex_antlr.py
+++ b/sympy/parsing/latex/_build_latex_antlr.py
@@ -61,8 +61,9 @@ def build_parser(output_dir=dir_latex_antlr):
     debug("Applying headers, removing unnecessary files and renaming...")
     # Handle case insensitive file systems. If the files are already
     # generated, they will be written to latex* but LaTeX*.* won't match them.
-    for path in (glob.glob(os.path.join(output_dir, "LaTeX*.*")) or
-        glob.glob(os.path.join(output_dir, "latex*.*"))):
+    for path in glob.glob(os.path.join(output_dir, "LaTeX*.*")) + glob.glob(
+        os.path.join(output_dir, "latex*.*")
+    ):
 
         # Remove files ending in .interp or .tokens as they are not needed.
         if not path.endswith(".py"):


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->
NA


#### Brief description of what is fixed or changed
When building antlr4 grammar using 
```
ANTLR4_TOOLS_ANTLR_VERSION=4.11.1 mise x python@3.12 -- python ./setup.py antlr
```

the header in `sympy/parsing/latex/_antlr/latexlexer.py` and `sympy/parsing/latex/_build_latex_antlr.py` files is not getting updated


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers. Formerly, `log(-x)` incorrectly gave `-log(x)`.

* physics.units
  * Corrected a semantical error in the conversion between volt and statvolt which
    reported the volt as being larger than the statvolt.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
